### PR TITLE
feat : 마케팅 동의 관련 api

### DIFF
--- a/.idea/sqldialects.xml
+++ b/.idea/sqldialects.xml
@@ -2,5 +2,6 @@
 <project version="4">
   <component name="SqlDialectMappings">
     <file url="file://$PROJECT_DIR$/BE/forever/src/main/resources/db/migration/V1__init_schema.sql" dialect="MySQL" />
+    <file url="file://$PROJECT_DIR$/BE/forever/src/main/resources/db/migration/V7__add_marketing_agreement_to_member.sql" dialect="GenericSQL" />
   </component>
 </project>

--- a/BE/forever/src/main/java/com/example/forever/application/member/MarketingAgreementApplicationService.java
+++ b/BE/forever/src/main/java/com/example/forever/application/member/MarketingAgreementApplicationService.java
@@ -1,0 +1,55 @@
+package com.example.forever.application.member;
+
+import com.example.forever.domain.member.MarketingAgreement;
+import com.example.forever.domain.member.MarketingAgreementService;
+import com.example.forever.domain.member.MemberId;
+import com.example.forever.dto.member.MarketingAgreementResponse;
+import com.example.forever.dto.member.MarketingAgreementUpdateRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.format.DateTimeFormatter;
+
+/**
+ * 마케팅 동의 관련 애플리케이션 서비스
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MarketingAgreementApplicationService {
+    
+    private final MarketingAgreementService marketingAgreementService;
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yy-MM-dd");
+    
+    /**
+     * 마케팅 동의 정보 조회
+     */
+    public MarketingAgreementResponse getMarketingAgreement(Long memberId) {
+        MemberId memberIdVO = MemberId.of(memberId);
+        MarketingAgreement agreement = marketingAgreementService.getMarketingAgreement(memberIdVO);
+        
+        return new MarketingAgreementResponse(
+                agreement.isAgreed(),
+                agreement.getAgreementDate().format(DATE_FORMATTER)
+        );
+    }
+    
+    /**
+     * 마케팅 동의 상태 변경
+     */
+    @Transactional
+    public MarketingAgreementResponse updateMarketingAgreement(Long memberId, 
+                                                               MarketingAgreementUpdateRequest request) {
+        MemberId memberIdVO = MemberId.of(memberId);
+        MarketingAgreement updatedAgreement = marketingAgreementService.updateMarketingAgreement(
+                memberIdVO, 
+                request.isAgreement()
+        );
+        
+        return new MarketingAgreementResponse(
+                updatedAgreement.isAgreed(),
+                updatedAgreement.getAgreementDate().format(DATE_FORMATTER)
+        );
+    }
+}

--- a/BE/forever/src/main/java/com/example/forever/application/member/MemberApplicationService.java
+++ b/BE/forever/src/main/java/com/example/forever/application/member/MemberApplicationService.java
@@ -31,6 +31,11 @@ public class MemberApplicationService {
                 email, nickname, school, major, command.inflow()
         );
         
+        // 마케팅 동의 설정
+        if (command.marketingAgreement() != null) {
+            newMember.setMarketingAgreement(command.marketingAgreement());
+        }
+        
         // 회원 저장
         Member savedMember = memberRepository.save(newMember);
         

--- a/BE/forever/src/main/java/com/example/forever/application/member/SignUpCommand.java
+++ b/BE/forever/src/main/java/com/example/forever/application/member/SignUpCommand.java
@@ -7,6 +7,7 @@ public record SignUpCommand(
         String major,
         String school,
         String email,
-        List<String> inflow
+        List<String> inflow,
+        Boolean marketingAgreement
 ) {
 }

--- a/BE/forever/src/main/java/com/example/forever/controller/AgreementController.java
+++ b/BE/forever/src/main/java/com/example/forever/controller/AgreementController.java
@@ -6,7 +6,9 @@ import com.example.forever.common.annotation.MemberInfo;
 import com.example.forever.common.response.ApiResponse;
 import com.example.forever.common.response.ApiResponseGenerator;
 import com.example.forever.dto.AgreementTermsResponse;
-import com.example.forever.dto.document.request.SaveQuestionAnswerRequest;
+import com.example.forever.dto.member.MarketingAgreementResponse;
+import com.example.forever.dto.member.MarketingAgreementUpdateRequest;
+import com.example.forever.application.member.MarketingAgreementApplicationService;
 import com.example.forever.service.AgreementService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -31,6 +33,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AgreementController {
 
     private final AgreementService agreementService;
+    private final MarketingAgreementApplicationService marketingAgreementApplicationService;
 
     @PatchMapping("/terms")
     @Operation(summary = "약관 동의", description = "서비스 이용약관에 동의합니다.")
@@ -85,6 +88,39 @@ public class AgreementController {
     public ApiResponse<ApiResponse.SuccesCustomBody<AgreementTermsResponse>> isPolicyAgreed(
             @Parameter(hidden = true) @AuthMember MemberInfo memberInfo){
         AgreementTermsResponse response = agreementService.isPolicyAgreed(memberInfo);
+        return ApiResponseGenerator.success(response, HttpStatus.OK);
+    }
+
+    @GetMapping("/marketing")
+    @Operation(summary = "마케팅 동의 상태 조회", description = "현재 사용자의 마케팅 동의 상태를 조회합니다.")
+    @SecurityRequirement(name = "Bearer Authentication")
+    @ApiResponses(value = {
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "마케팅 동의 상태 조회 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "존재하지 않는 회원")
+    })
+    public ApiResponse<ApiResponse.SuccesCustomBody<MarketingAgreementResponse>> getMarketingAgreement(
+            @Parameter(hidden = true) @AuthMember MemberInfo memberInfo) {
+        MarketingAgreementResponse response = marketingAgreementApplicationService
+                .getMarketingAgreement(memberInfo.getMemberId());
+        return ApiResponseGenerator.success(response, HttpStatus.OK);
+    }
+
+    @PatchMapping("/marketing")
+    @Operation(summary = "마케팅 동의 상태 변경", description = "현재 사용자의 마케팅 동의 상태를 변경합니다.")
+    @SecurityRequirement(name = "Bearer Authentication")
+    @ApiResponses(value = {
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "마케팅 동의 상태 변경 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "존재하지 않는 회원"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청 데이터")
+    })
+    public ApiResponse<ApiResponse.SuccesCustomBody<MarketingAgreementResponse>> updateMarketingAgreement(
+            @Parameter(hidden = true) @AuthMember MemberInfo memberInfo,
+            @Parameter(description = "마케팅 동의 변경 요청", required = true)
+            @Valid @RequestBody MarketingAgreementUpdateRequest request) {
+        MarketingAgreementResponse response = marketingAgreementApplicationService
+                .updateMarketingAgreement(memberInfo.getMemberId(), request);
         return ApiResponseGenerator.success(response, HttpStatus.OK);
     }
 

--- a/BE/forever/src/main/java/com/example/forever/domain/Member.java
+++ b/BE/forever/src/main/java/com/example/forever/domain/Member.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import lombok.*;
+import com.example.forever.domain.member.MarketingAgreement;
 import com.example.forever.exception.token.InsufficientTokenException;
 
 @Entity
@@ -14,7 +15,7 @@ import com.example.forever.exception.token.InsufficientTokenException;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-public class Member extends BaseTimeEntity{
+public class Member extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -73,10 +74,15 @@ public class Member extends BaseTimeEntity{
     @Column(name = "effective_date_terms", nullable = false)
     private LocalDate effectiveDateTerms = LocalDate.of(2025, 4, 3);
 
+    @Embedded
+    @Builder.Default
+    private MarketingAgreement marketingAgreement = MarketingAgreement.of(false);
+
 
     public void updateRefreshToken(String token) {
         this.refreshToken = token;
     }
+
     public void updateKakaoAccessToken(String token) {
         this.kakaoAccessToken = token;
     }
@@ -116,9 +122,23 @@ public class Member extends BaseTimeEntity{
         this.isAgreedTerms = true;
     }
 
-    public void delete(){
+    public void delete() {
         this.isDeleted = true;
         this.deletedAt = LocalDateTime.now();
+    }
+
+    /**
+     * 마케팅 동의 상태 변경 DDD의 Aggregate Root가 자신의 상태 변경을 관리
+     */
+    public void updateMarketingAgreement(boolean isAgreed) {
+        this.marketingAgreement = this.marketingAgreement.updateAgreement(isAgreed);
+    }
+
+    /**
+     * 마케팅 동의 정보 설정 (생성 시에만 사용)
+     */
+    public void setMarketingAgreement(boolean isAgreed) {
+        this.marketingAgreement = MarketingAgreement.of(isAgreed);
     }
 
 }

--- a/BE/forever/src/main/java/com/example/forever/domain/member/MarketingAgreement.java
+++ b/BE/forever/src/main/java/com/example/forever/domain/member/MarketingAgreement.java
@@ -21,7 +21,7 @@ import java.util.Objects;
 public class MarketingAgreement {
     
     @Column(name = "marketing_agreement")
-    private Boolean isAgreed;
+    private boolean isAgreed;
     
     @Column(name = "marketing_agreement_date")
     private LocalDateTime agreementDate;

--- a/BE/forever/src/main/java/com/example/forever/domain/member/MarketingAgreement.java
+++ b/BE/forever/src/main/java/com/example/forever/domain/member/MarketingAgreement.java
@@ -1,0 +1,74 @@
+package com.example.forever.domain.member;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+/**
+ * 마케팅 동의 정보를 나타내는 Value Object
+ * DDD의 Value Object 패턴을 적용하여 마케팅 동의와 관련된 데이터를 캡슐화
+ */
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class MarketingAgreement {
+    
+    @Column(name = "marketing_agreement")
+    private Boolean isAgreed;
+    
+    @Column(name = "marketing_agreement_date")
+    private LocalDateTime agreementDate;
+    
+    /**
+     * 마케팅 동의 생성 팩토리 메서드
+     */
+    public static MarketingAgreement of(boolean isAgreed) {
+        return new MarketingAgreement(isAgreed, LocalDateTime.now());
+    }
+    
+    /**
+     * 마케팅 동의 상태 변경
+     * 불변성을 위해 새로운 객체를 반환
+     */
+    public MarketingAgreement updateAgreement(boolean newAgreement) {
+        if (this.isAgreed == newAgreement) {
+            return this;
+        }
+        return new MarketingAgreement(newAgreement, LocalDateTime.now());
+    }
+    
+    /**
+     * 동의 여부 확인
+     */
+    public boolean isAgreed() {
+        return Boolean.TRUE.equals(isAgreed);
+    }
+    
+    /**
+     * 동의 날짜 조회 (방어적 복사)
+     */
+    public LocalDateTime getAgreementDate() {
+        return agreementDate;
+    }
+    
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        MarketingAgreement that = (MarketingAgreement) o;
+        return Objects.equals(isAgreed, that.isAgreed) && 
+               Objects.equals(agreementDate, that.agreementDate);
+    }
+    
+    @Override
+    public int hashCode() {
+        return Objects.hash(isAgreed, agreementDate);
+    }
+}

--- a/BE/forever/src/main/java/com/example/forever/domain/member/MarketingAgreementService.java
+++ b/BE/forever/src/main/java/com/example/forever/domain/member/MarketingAgreementService.java
@@ -1,0 +1,41 @@
+package com.example.forever.domain.member;
+
+import com.example.forever.domain.Member;
+import com.example.forever.exception.auth.MemberNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 마케팅 동의 관련 도메인 서비스
+ * DDD의 Domain Service 패턴을 적용하여 비즈니스 로직을 캡슐화
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MarketingAgreementService {
+    
+    private final MemberDomainRepository memberDomainRepository;
+    
+    /**
+     * 회원의 마케팅 동의 정보 조회
+     */
+    public MarketingAgreement getMarketingAgreement(MemberId memberId) {
+        Member member = memberDomainRepository.findById(memberId.getValue())
+                .orElseThrow(() -> new MemberNotFoundException("회원을 찾을 수 없습니다."));
+        return member.getMarketingAgreement();
+    }
+    
+    /**
+     * 마케팅 동의 상태 변경
+     */
+    @Transactional
+    public MarketingAgreement updateMarketingAgreement(MemberId memberId, boolean isAgreed) {
+        Member member = memberDomainRepository.findById(memberId.getValue())
+                .orElseThrow(() -> new MemberNotFoundException("회원을 찾을 수 없습니다."));
+        member.updateMarketingAgreement(isAgreed);
+        
+        Member savedMember = memberDomainRepository.save(member);
+        return savedMember.getMarketingAgreement();
+    }
+}

--- a/BE/forever/src/main/java/com/example/forever/domain/member/MemberId.java
+++ b/BE/forever/src/main/java/com/example/forever/domain/member/MemberId.java
@@ -20,6 +20,10 @@ public class MemberId {
             throw new IllegalArgumentException("회원 ID는 양수여야 합니다.");
         }
     }
+
+    public static MemberId of(Long value) {
+        return new MemberId(value);
+    }
     
     @Override
     public boolean equals(Object obj) {

--- a/BE/forever/src/main/java/com/example/forever/dto/member/MarketingAgreementResponse.java
+++ b/BE/forever/src/main/java/com/example/forever/dto/member/MarketingAgreementResponse.java
@@ -1,0 +1,15 @@
+package com.example.forever.dto.member;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * 마케팅 동의 조회 응답 DTO
+ */
+public record MarketingAgreementResponse(
+        @JsonProperty("is_agreement")
+        Boolean isAgreement,
+        
+        @JsonProperty("effective_date")
+        String effectiveDate
+) {
+}

--- a/BE/forever/src/main/java/com/example/forever/dto/member/MarketingAgreementUpdateRequest.java
+++ b/BE/forever/src/main/java/com/example/forever/dto/member/MarketingAgreementUpdateRequest.java
@@ -1,0 +1,14 @@
+package com.example.forever.dto.member;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * 마케팅 동의 변경 요청 DTO
+ */
+public record MarketingAgreementUpdateRequest(
+        @JsonProperty("is_agreement")
+        @NotNull(message = "마케팅 동의 여부는 필수입니다.")
+        Boolean isAgreement
+) {
+}

--- a/BE/forever/src/main/java/com/example/forever/dto/member/SignUpRequest.java
+++ b/BE/forever/src/main/java/com/example/forever/dto/member/SignUpRequest.java
@@ -1,5 +1,6 @@
 package com.example.forever.dto.member;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 
 public record SignUpRequest(
@@ -7,6 +8,8 @@ public record SignUpRequest(
         String major,
         String school,
         String email,
-        List<String> inflow
+        List<String> inflow,
+        @JsonProperty("marketing_agreement")
+        Boolean marketingAgreement
 ) {
 }

--- a/BE/forever/src/main/java/com/example/forever/exception/auth/MemberNotFoundException.java
+++ b/BE/forever/src/main/java/com/example/forever/exception/auth/MemberNotFoundException.java
@@ -7,4 +7,8 @@ public class MemberNotFoundException extends AuthException {
     public MemberNotFoundException(Long memberId) {
         super(AuthErrorCode.MEMBER_NOT_FOUND);
     }
+    
+    public MemberNotFoundException(String message) {
+        super(AuthErrorCode.MEMBER_NOT_FOUND);
+    }
 }

--- a/BE/forever/src/main/java/com/example/forever/interfaces/web/auth/AuthController.java
+++ b/BE/forever/src/main/java/com/example/forever/interfaces/web/auth/AuthController.java
@@ -85,7 +85,8 @@ public class AuthController {
                 request.major(),
                 request.school(),
                 request.email(),
-                request.inflow()
+                request.inflow(),
+                request.marketingAgreement()
         );
         
         memberApplicationService.signUp(command, response);

--- a/BE/forever/src/main/resources/db/migration/V7__add_marketing_agreement_to_member.sql
+++ b/BE/forever/src/main/resources/db/migration/V7__add_marketing_agreement_to_member.sql
@@ -1,0 +1,13 @@
+-- Add marketing agreement fields to member_tb table (V7)
+-- MySQL does not support "ADD COLUMN IF NOT EXISTS" syntax
+-- Flyway ensures this migration runs only once per environment
+
+ALTER TABLE member_tb 
+ADD COLUMN marketing_agreement BOOLEAN DEFAULT FALSE COMMENT '마케팅 동의 여부',
+ADD COLUMN marketing_agreement_date DATETIME COMMENT '마케팅 동의 유효날짜';
+
+-- Update existing members with default values  
+UPDATE member_tb 
+SET marketing_agreement = FALSE, 
+    marketing_agreement_date = NOW() 
+WHERE marketing_agreement IS NULL;

--- a/BE/forever/src/test/java/com/example/forever/application/member/MarketingAgreementApplicationServiceTest.java
+++ b/BE/forever/src/test/java/com/example/forever/application/member/MarketingAgreementApplicationServiceTest.java
@@ -1,0 +1,121 @@
+package com.example.forever.application.member;
+
+import com.example.forever.domain.member.MarketingAgreement;
+import com.example.forever.domain.member.MarketingAgreementService;
+import com.example.forever.domain.member.MemberId;
+import com.example.forever.dto.member.MarketingAgreementResponse;
+import com.example.forever.dto.member.MarketingAgreementUpdateRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MarketingAgreementApplicationService 단위 테스트")
+class MarketingAgreementApplicationServiceTest {
+
+    @Mock
+    private MarketingAgreementService marketingAgreementService;
+
+    @InjectMocks
+    private MarketingAgreementApplicationService applicationService;
+
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yy-MM-dd");
+
+    @Test
+    @DisplayName("마케팅 동의 정보 조회 성공")
+    void getMarketingAgreement_Success() {
+        // given
+        Long memberId = 1L;
+        LocalDateTime agreementDate = LocalDateTime.of(2025, 6, 8, 12, 0);
+        MarketingAgreement agreement = MarketingAgreement.of(true);
+
+        when(marketingAgreementService.getMarketingAgreement(any(MemberId.class)))
+                .thenReturn(createMarketingAgreementWithDate(true, agreementDate));
+
+        // when
+        MarketingAgreementResponse response = applicationService.getMarketingAgreement(memberId);
+
+        // then
+        assertThat(response.isAgreement()).isTrue();
+        assertThat(response.effectiveDate()).isEqualTo("25-06-08");
+        verify(marketingAgreementService).getMarketingAgreement(MemberId.of(memberId));
+    }
+
+    @Test
+    @DisplayName("마케팅 동의 정보 조회 - 동의하지 않음")
+    void getMarketingAgreement_NotAgreed() {
+        // given
+        Long memberId = 1L;
+        LocalDateTime agreementDate = LocalDateTime.of(2025, 6, 8, 15, 30);
+
+        when(marketingAgreementService.getMarketingAgreement(any(MemberId.class)))
+                .thenReturn(createMarketingAgreementWithDate(false, agreementDate));
+
+        // when
+        MarketingAgreementResponse response = applicationService.getMarketingAgreement(memberId);
+
+        // then
+        assertThat(response.isAgreement()).isFalse();
+        assertThat(response.effectiveDate()).isEqualTo("25-06-08");
+    }
+
+    @Test
+    @DisplayName("마케팅 동의 상태 변경 성공 - 동의함으로 변경")
+    void updateMarketingAgreement_ToAgreed_Success() {
+        // given
+        Long memberId = 1L;
+        MarketingAgreementUpdateRequest request = new MarketingAgreementUpdateRequest(true);
+        LocalDateTime updatedDate = LocalDateTime.of(2025, 6, 8, 16, 45);
+
+        when(marketingAgreementService.updateMarketingAgreement(any(MemberId.class), eq(true)))
+                .thenReturn(createMarketingAgreementWithDate(true, updatedDate));
+
+        // when
+        MarketingAgreementResponse response = applicationService.updateMarketingAgreement(memberId, request);
+
+        // then
+        assertThat(response.isAgreement()).isTrue();
+        assertThat(response.effectiveDate()).isEqualTo("25-06-08");
+        verify(marketingAgreementService).updateMarketingAgreement(MemberId.of(memberId), true);
+    }
+
+    @Test
+    @DisplayName("마케팅 동의 상태 변경 성공 - 동의하지 않음으로 변경")
+    void updateMarketingAgreement_ToNotAgreed_Success() {
+        // given
+        Long memberId = 1L;
+        MarketingAgreementUpdateRequest request = new MarketingAgreementUpdateRequest(false);
+        LocalDateTime updatedDate = LocalDateTime.of(2025, 12, 25, 10, 30);
+
+        when(marketingAgreementService.updateMarketingAgreement(any(MemberId.class), eq(false)))
+                .thenReturn(createMarketingAgreementWithDate(false, updatedDate));
+
+        // when
+        MarketingAgreementResponse response = applicationService.updateMarketingAgreement(memberId, request);
+
+        // then
+        assertThat(response.isAgreement()).isFalse();
+        verify(marketingAgreementService).updateMarketingAgreement(MemberId.of(memberId), false);
+    }
+
+    /**
+     * 테스트용 MarketingAgreement 생성 (특정 날짜 포함)
+     */
+    private MarketingAgreement createMarketingAgreementWithDate(boolean isAgreed, LocalDateTime date) {
+        MarketingAgreement mockAgreement = MarketingAgreement.of(isAgreed);
+        // 단순화를 위해 현재 시간 사용
+        return mockAgreement;
+    }
+}

--- a/BE/forever/src/test/java/com/example/forever/controller/AuthControllerTest.java
+++ b/BE/forever/src/test/java/com/example/forever/controller/AuthControllerTest.java
@@ -89,7 +89,8 @@ class AuthControllerTest {
                 "컴퓨터공학",
                 "테스트대학교",
                 "test@example.com",
-                List.of("인플로우1", "인플로우2")
+                List.of("인플로우1", "인플로우2"),
+                true
         );
         
         doNothing().when(memberApplicationService).signUp(any(), any());

--- a/BE/forever/src/test/java/com/example/forever/controller/MarketingAgreementControllerTest.java
+++ b/BE/forever/src/test/java/com/example/forever/controller/MarketingAgreementControllerTest.java
@@ -1,0 +1,127 @@
+package com.example.forever.controller;
+
+import com.example.forever.application.member.MarketingAgreementApplicationService;
+import com.example.forever.common.test.TestMemberArgumentResolver;
+import com.example.forever.dto.member.MarketingAgreementResponse;
+import com.example.forever.dto.member.MarketingAgreementUpdateRequest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("마케팅 동의 API 컨트롤러 테스트")
+class MarketingAgreementControllerTest {
+
+    private MockMvc mockMvc;
+    private ObjectMapper objectMapper;
+
+    @Mock
+    private MarketingAgreementApplicationService marketingAgreementApplicationService;
+
+    @InjectMocks
+    private AgreementController agreementController;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        mockMvc = MockMvcBuilders.standaloneSetup(agreementController)
+                .setCustomArgumentResolvers(new TestMemberArgumentResolver())
+                .build();
+    }
+
+    @Test
+    @DisplayName("마케팅 동의 상태 조회 API 테스트 - 성공")
+    void getMarketingAgreement_Success() throws Exception {
+        // given
+        Long memberId = 1L;
+        MarketingAgreementResponse response = new MarketingAgreementResponse(true, "25-06-08");
+        
+        when(marketingAgreementApplicationService.getMarketingAgreement(memberId))
+                .thenReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/agreement/marketing")
+                        .header("Authorization", "Bearer test-token"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.data.is_agreement").value(true))
+                .andExpect(jsonPath("$.data.effective_date").value("25-06-08"));
+
+        verify(marketingAgreementApplicationService).getMarketingAgreement(memberId);
+    }
+
+    @Test
+    @DisplayName("마케팅 동의 상태 변경 API 테스트 - 동의함으로 변경")
+    void updateMarketingAgreement_ToAgreed_Success() throws Exception {
+        // given
+        Long memberId = 1L;
+        MarketingAgreementUpdateRequest request = new MarketingAgreementUpdateRequest(true);
+        MarketingAgreementResponse response = new MarketingAgreementResponse(true, "25-06-08");
+        
+        when(marketingAgreementApplicationService.updateMarketingAgreement(eq(memberId), any()))
+                .thenReturn(response);
+
+        // when & then
+        mockMvc.perform(patch("/api/agreement/marketing")
+                        .header("Authorization", "Bearer test-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.data.is_agreement").value(true))
+                .andExpect(jsonPath("$.data.effective_date").value("25-06-08"));
+
+        verify(marketingAgreementApplicationService).updateMarketingAgreement(eq(memberId), any(MarketingAgreementUpdateRequest.class));
+    }
+
+    @Test
+    @DisplayName("마케팅 동의 상태 변경 API 테스트 - 동의하지 않음으로 변경")
+    void updateMarketingAgreement_ToNotAgreed_Success() throws Exception {
+        // given
+        Long memberId = 1L;
+        MarketingAgreementUpdateRequest request = new MarketingAgreementUpdateRequest(false);
+        MarketingAgreementResponse response = new MarketingAgreementResponse(false, "25-06-08");
+        
+        when(marketingAgreementApplicationService.updateMarketingAgreement(eq(memberId), any()))
+                .thenReturn(response);
+
+        // when & then
+        mockMvc.perform(patch("/api/agreement/marketing")
+                        .header("Authorization", "Bearer test-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.is_agreement").value(false));
+    }
+
+    @Test
+    @DisplayName("마케팅 동의 상태 변경 API 테스트 - 잘못된 요청 데이터")
+    void updateMarketingAgreement_InvalidRequest() throws Exception {
+        // given
+        String invalidJson = "{ \"is_agreement\": null }";
+
+        // when & then
+        mockMvc.perform(patch("/api/agreement/marketing")
+                        .header("Authorization", "Bearer test-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(invalidJson))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/BE/forever/src/test/java/com/example/forever/domain/MemberMarketingAgreementTest.java
+++ b/BE/forever/src/test/java/com/example/forever/domain/MemberMarketingAgreementTest.java
@@ -1,0 +1,101 @@
+package com.example.forever.domain;
+
+import com.example.forever.domain.member.MarketingAgreement;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Member 엔티티의 마케팅 동의 기능 테스트")
+class MemberMarketingAgreementTest {
+
+    @Test
+    @DisplayName("Member 생성 시 기본 마케팅 동의는 false")
+    void createMember_DefaultMarketingAgreementIsFalse() {
+        // given & when
+        Member member = Member.builder()
+                .email("test@example.com")
+                .nickname("테스트")
+                .build();
+
+        // then
+        assertThat(member.getMarketingAgreement()).isNotNull();
+        assertThat(member.getMarketingAgreement().isAgreed()).isFalse();
+    }
+
+    @Test
+    @DisplayName("회원가입 시 마케팅 동의 설정")
+    void setMarketingAgreement_OnSignup() {
+        // given
+        Member member = Member.builder()
+                .email("test@example.com")
+                .nickname("테스트")
+                .build();
+
+        // when
+        member.setMarketingAgreement(true);
+
+        // then
+        assertThat(member.getMarketingAgreement().isAgreed()).isTrue();
+        assertThat(member.getMarketingAgreement().getAgreementDate()).isBefore(LocalDateTime.now().plusSeconds(1));
+    }
+
+    @Test
+    @DisplayName("마케팅 동의 상태 변경")
+    void updateMarketingAgreement() {
+        // given
+        Member member = Member.builder()
+                .email("test@example.com")
+                .nickname("테스트")
+                .build();
+        member.setMarketingAgreement(false);
+        LocalDateTime originalDate = member.getMarketingAgreement().getAgreementDate();
+
+        // when
+        member.updateMarketingAgreement(true);
+
+        // then
+        assertThat(member.getMarketingAgreement().isAgreed()).isTrue();
+        assertThat(member.getMarketingAgreement().getAgreementDate()).isAfter(originalDate);
+    }
+
+    @Test
+    @DisplayName("마케팅 동의 상태를 같은 값으로 변경해도 정상 동작")
+    void updateMarketingAgreement_SameValue() {
+        // given
+        Member member = Member.builder()
+                .email("test@example.com")
+                .nickname("테스트")
+                .build();
+        member.setMarketingAgreement(true);
+        MarketingAgreement originalAgreement = member.getMarketingAgreement();
+
+        // when
+        member.updateMarketingAgreement(true);
+
+        // then
+        assertThat(member.getMarketingAgreement()).isSameAs(originalAgreement);
+    }
+
+    @Test
+    @DisplayName("마케팅 동의 여러 번 변경 테스트")
+    void updateMarketingAgreement_MultipleTimes() {
+        // given
+        Member member = Member.builder()
+                .email("test@example.com")
+                .nickname("테스트")
+                .build();
+
+        // when & then
+        member.setMarketingAgreement(true);
+        assertThat(member.getMarketingAgreement().isAgreed()).isTrue();
+
+        member.updateMarketingAgreement(false);
+        assertThat(member.getMarketingAgreement().isAgreed()).isFalse();
+
+        member.updateMarketingAgreement(true);
+        assertThat(member.getMarketingAgreement().isAgreed()).isTrue();
+    }
+}

--- a/BE/forever/src/test/java/com/example/forever/domain/member/MarketingAgreementServiceTest.java
+++ b/BE/forever/src/test/java/com/example/forever/domain/member/MarketingAgreementServiceTest.java
@@ -1,0 +1,131 @@
+package com.example.forever.domain.member;
+
+import com.example.forever.domain.Member;
+import com.example.forever.exception.auth.MemberNotFoundException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MarketingAgreementService 단위 테스트")
+class MarketingAgreementServiceTest {
+
+    @Mock
+    private MemberDomainRepository memberDomainRepository;
+
+    @InjectMocks
+    private MarketingAgreementService marketingAgreementService;
+
+    @Test
+    @DisplayName("마케팅 동의 정보 조회 성공")
+    void getMarketingAgreement_Success() {
+        // given
+        Long memberId = 1L;
+        MemberId memberIdVO = MemberId.of(memberId);
+        Member member = createMemberWithMarketingAgreement(true);
+
+        when(memberDomainRepository.findById(memberId)).thenReturn(Optional.of(member));
+
+        // when
+        MarketingAgreement result = marketingAgreementService.getMarketingAgreement(memberIdVO);
+
+        // then
+        assertThat(result.isAgreed()).isTrue();
+        verify(memberDomainRepository).findById(memberId);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 회원의 마케팅 동의 정보 조회 시 예외 발생")
+    void getMarketingAgreement_MemberNotFound_ThrowsException() {
+        // given
+        Long memberId = 999L;
+        MemberId memberIdVO = MemberId.of(memberId);
+
+        when(memberDomainRepository.findById(memberId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> marketingAgreementService.getMarketingAgreement(memberIdVO))
+                .isInstanceOf(MemberNotFoundException.class);
+
+        verify(memberDomainRepository).findById(memberId);
+    }
+
+    @Test
+    @DisplayName("마케팅 동의 상태 변경 성공")
+    void updateMarketingAgreement_Success() {
+        // given
+        Long memberId = 1L;
+        MemberId memberIdVO = MemberId.of(memberId);
+        Member member = createMemberWithMarketingAgreement(false);
+        Member savedMember = createMemberWithMarketingAgreement(true);
+
+        when(memberDomainRepository.findById(memberId)).thenReturn(Optional.of(member));
+        when(memberDomainRepository.save(any(Member.class))).thenReturn(savedMember);
+
+        // when
+        MarketingAgreement result = marketingAgreementService.updateMarketingAgreement(memberIdVO, true);
+
+        // then
+        assertThat(result.isAgreed()).isTrue();
+        verify(memberDomainRepository).findById(memberId);
+        verify(memberDomainRepository).save(member);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 회원의 마케팅 동의 상태 변경 시 예외 발생")
+    void updateMarketingAgreement_MemberNotFound_ThrowsException() {
+        // given
+        Long memberId = 999L;
+        MemberId memberIdVO = MemberId.of(memberId);
+
+        when(memberDomainRepository.findById(memberId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> marketingAgreementService.updateMarketingAgreement(memberIdVO, true))
+                .isInstanceOf(MemberNotFoundException.class);
+
+        verify(memberDomainRepository).findById(memberId);
+        verify(memberDomainRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("마케팅 동의를 동일한 상태로 변경")
+    void updateMarketingAgreement_SameState() {
+        // given
+        Long memberId = 1L;
+        MemberId memberIdVO = MemberId.of(memberId);
+        Member member = createMemberWithMarketingAgreement(true);
+
+        when(memberDomainRepository.findById(memberId)).thenReturn(Optional.of(member));
+        when(memberDomainRepository.save(any(Member.class))).thenReturn(member);
+
+        // when
+        MarketingAgreement result = marketingAgreementService.updateMarketingAgreement(memberIdVO, true);
+
+        // then
+        assertThat(result.isAgreed()).isTrue();
+        verify(memberDomainRepository).save(member);
+    }
+
+    private Member createMemberWithMarketingAgreement(boolean isAgreed) {
+        Member member = Member.builder()
+                .id(1L)
+                .email("test@example.com")
+                .nickname("테스트회원")
+                .major("컴퓨터공학과")
+                .school("테스트대학교")
+                .build();
+        member.setMarketingAgreement(isAgreed);
+        return member;
+    }
+}

--- a/BE/forever/src/test/java/com/example/forever/domain/member/MarketingAgreementTest.java
+++ b/BE/forever/src/test/java/com/example/forever/domain/member/MarketingAgreementTest.java
@@ -1,0 +1,107 @@
+package com.example.forever.domain.member;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("MarketingAgreement Value Object 테스트")
+class MarketingAgreementTest {
+
+    @Test
+    @DisplayName("마케팅 동의 생성 - 동의함")
+    void createMarketingAgreement_Agreed() {
+        // given & when
+        MarketingAgreement agreement = MarketingAgreement.of(true);
+
+        // then
+        assertThat(agreement.isAgreed()).isTrue();
+        assertThat(agreement.getAgreementDate()).isBefore(LocalDateTime.now().plusSeconds(1));
+        assertThat(agreement.getAgreementDate()).isAfter(LocalDateTime.now().minusSeconds(1));
+    }
+
+    @Test
+    @DisplayName("마케팅 동의 생성 - 동의하지 않음")
+    void createMarketingAgreement_NotAgreed() {
+        // given & when
+        MarketingAgreement agreement = MarketingAgreement.of(false);
+
+        // then
+        assertThat(agreement.isAgreed()).isFalse();
+        assertThat(agreement.getAgreementDate()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("마케팅 동의 상태 변경 - 동의하지 않음에서 동의함으로")
+    void updateAgreement_FromFalseToTrue() {
+        // given
+        MarketingAgreement originalAgreement = MarketingAgreement.of(false);
+        LocalDateTime originalDate = originalAgreement.getAgreementDate();
+
+        // when
+        MarketingAgreement updatedAgreement = originalAgreement.updateAgreement(true);
+
+        // then
+        assertThat(updatedAgreement.isAgreed()).isTrue();
+        assertThat(updatedAgreement.getAgreementDate()).isAfter(originalDate);
+        assertThat(originalAgreement.isAgreed()).isFalse(); // 원본 불변성 확인
+    }
+
+    @Test
+    @DisplayName("마케팅 동의 상태 변경 - 동일한 상태로 변경 시 같은 객체 반환")
+    void updateAgreement_SameState_ReturnsSameObject() {
+        // given
+        MarketingAgreement agreement = MarketingAgreement.of(true);
+
+        // when
+        MarketingAgreement updatedAgreement = agreement.updateAgreement(true);
+
+        // then
+        assertThat(updatedAgreement).isSameAs(agreement);
+    }
+
+    @Test
+    @DisplayName("마케팅 동의 상태 변경 - 동의함에서 동의하지 않음으로")
+    void updateAgreement_FromTrueToFalse() {
+        // given
+        MarketingAgreement originalAgreement = MarketingAgreement.of(true);
+        LocalDateTime originalDate = originalAgreement.getAgreementDate();
+
+        // when
+        MarketingAgreement updatedAgreement = originalAgreement.updateAgreement(false);
+
+        // then
+        assertThat(updatedAgreement.isAgreed()).isFalse();
+        assertThat(updatedAgreement.getAgreementDate()).isAfter(originalDate);
+    }
+
+    @Test
+    @DisplayName("equals와 hashCode 테스트")
+    void testEqualsAndHashCode() {
+        // given
+        MarketingAgreement agreement1 = MarketingAgreement.of(true);
+        MarketingAgreement agreement2 = MarketingAgreement.of(true);
+
+        // when & then
+        assertThat(agreement1).isNotEqualTo(agreement2); // 생성 시간이 다르므로 다름
+        assertThat(agreement1.hashCode()).isNotEqualTo(agreement2.hashCode());
+        
+        // 같은 객체는 같음
+        assertThat(agreement1).isEqualTo(agreement1);
+        assertThat(agreement1.hashCode()).isEqualTo(agreement1.hashCode());
+    }
+
+    @Test
+    @DisplayName("Null 안전성 테스트")
+    void testNullSafety() {
+        // given
+        MarketingAgreement agreement = MarketingAgreement.of(false);
+
+        // when & then
+        assertThat(agreement).isNotEqualTo(null);
+        assertThat(agreement.getIsAgreed()).isNotNull();
+        assertThat(agreement.getAgreementDate()).isNotNull();
+    }
+}

--- a/BE/forever/src/test/java/com/example/forever/fixture/MemberFixture.java
+++ b/BE/forever/src/test/java/com/example/forever/fixture/MemberFixture.java
@@ -16,7 +16,8 @@ public class MemberFixture {
                 "컴퓨터공학과",
                 "테스트대학교",
                 "test@example.com",
-                List.of("지인추천", "검색")
+                List.of("지인추천", "검색"),
+                true
         );
     }
 
@@ -26,7 +27,8 @@ public class MemberFixture {
                 "컴퓨터공학과",
                 "테스트대학교",
                 email,
-                List.of("지인추천")
+                List.of("지인추천"),
+                true
         );
     }
 
@@ -36,7 +38,8 @@ public class MemberFixture {
                 "컴퓨터공학과",
                 "테스트대학교",
                 "test@example.com",
-                inflow
+                inflow,
+                true
         );
     }
 
@@ -46,7 +49,44 @@ public class MemberFixture {
                 "컴퓨터공학과",
                 "테스트대학교",
                 "test@example.com",
-                List.of("지인추천")
+                List.of("지인추천"),
+                true
+        );
+    }
+
+    /**
+     * 마케팅 동의 관련 테스트용 SignUpRequest 생성 메서드들
+     */
+    public static SignUpRequest createSignUpRequestWithMarketingAgreement(boolean marketingAgreement) {
+        return new SignUpRequest(
+                "김테스트",
+                "컴퓨터공학과",
+                "테스트대학교",
+                "test@example.com",
+                List.of("지인추천"),
+                marketingAgreement
+        );
+    }
+
+    public static SignUpRequest createSignUpRequestWithEmailAndMarketingAgreement(String email, Boolean marketingAgreement) {
+        return new SignUpRequest(
+                "김테스트",
+                "컴퓨터공학과",
+                "테스트대학교",
+                email,
+                List.of("지인추천"),
+                marketingAgreement
+        );
+    }
+
+    public static SignUpRequest createSignUpRequestWithNullMarketingAgreement() {
+        return new SignUpRequest(
+                "김테스트",
+                "컴퓨터공학과",
+                "테스트대학교",
+                "test@example.com",
+                List.of("지인추천"),
+                null
         );
     }
 
@@ -68,5 +108,32 @@ public class MemberFixture {
                 .school("테스트대학교")
                 .inflow("지인추천")
                 .build();
+    }
+
+    /**
+     * 마케팅 동의 관련 테스트용 Member 생성 메서드들
+     */
+    public static Member createMemberWithMarketingAgreement(boolean marketingAgreement) {
+        Member member = Member.builder()
+                .email("member@example.com")
+                .nickname("테스트회원")
+                .major("소프트웨어공학과")
+                .school("테스트대학교")
+                .inflow("지인추천,검색")
+                .build();
+        member.setMarketingAgreement(marketingAgreement);
+        return member;
+    }
+
+    public static Member createMemberWithEmailAndMarketingAgreement(String email, boolean marketingAgreement) {
+        Member member = Member.builder()
+                .email(email)
+                .nickname("테스트회원")
+                .major("소프트웨어공학과")
+                .school("테스트대학교")
+                .inflow("지인추천")
+                .build();
+        member.setMarketingAgreement(marketingAgreement);
+        return member;
     }
 }

--- a/BE/forever/src/test/java/com/example/forever/integration/BasicIntegrationTest.java
+++ b/BE/forever/src/test/java/com/example/forever/integration/BasicIntegrationTest.java
@@ -44,7 +44,8 @@ class BasicIntegrationTest {
                 "소프트웨어공학과",
                 "전남대학교",
                 "rootachieve@gmail.com",
-                List.of("지인추천", "기타")
+                List.of("지인추천", "기타"),
+                true
         );
         
         MockHttpServletResponse response = new MockHttpServletResponse();
@@ -80,7 +81,8 @@ class BasicIntegrationTest {
                 "컴퓨터공학과",
                 "테스트대학교",
                 "test@example.com",
-                null
+                null,
+                false
         );
         
         MockHttpServletResponse response = new MockHttpServletResponse();
@@ -103,7 +105,8 @@ class BasicIntegrationTest {
                 "빈리스트학과",
                 "빈리스트대학교",
                 "empty@example.com",
-                List.of()
+                List.of(),
+                null
         );
         
         MockHttpServletResponse response = new MockHttpServletResponse();

--- a/BE/forever/src/test/java/com/example/forever/integration/MarketingAgreementIntegrationTest.java
+++ b/BE/forever/src/test/java/com/example/forever/integration/MarketingAgreementIntegrationTest.java
@@ -1,0 +1,204 @@
+package com.example.forever.integration;
+
+import com.example.forever.application.member.MarketingAgreementApplicationService;
+import com.example.forever.application.member.MemberApplicationService;
+import com.example.forever.application.member.SignUpCommand;
+import com.example.forever.domain.Member;
+import com.example.forever.dto.member.MarketingAgreementResponse;
+import com.example.forever.dto.member.MarketingAgreementUpdateRequest;
+import com.example.forever.repository.MemberRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+@DisplayName("마케팅 동의 통합 테스트")
+class MarketingAgreementIntegrationTest {
+
+    @Autowired
+    private MarketingAgreementApplicationService marketingAgreementApplicationService;
+
+    @Autowired
+    private MemberApplicationService memberApplicationService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @BeforeEach
+    void setUp() {
+        memberRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("회원가입 시 마케팅 동의 포함하여 저장")
+    void signUpWithMarketingAgreement() {
+        // given
+        SignUpCommand command = new SignUpCommand(
+                "곽민주",
+                "소프트웨어공학과",
+                "전남대학교",
+                "rootachieve@gmail.com",
+                List.of("지인추천", "기타"),
+                true
+        );
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        // when
+        memberApplicationService.signUp(command, response);
+
+        // then
+        Optional<Member> savedMember = memberRepository.findByEmail("rootachieve@gmail.com");
+        assertThat(savedMember).isPresent();
+        assertThat(savedMember.get().getMarketingAgreement().isAgreed()).isTrue();
+        assertThat(savedMember.get().getMarketingAgreement().getAgreementDate()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("회원가입 시 마케팅 동의하지 않음으로 저장")
+    void signUpWithoutMarketingAgreement() {
+        // given
+        SignUpCommand command = new SignUpCommand(
+                "테스트유저",
+                "컴퓨터공학과",
+                "테스트대학교",
+                "test@example.com",
+                List.of("검색"),
+                false
+        );
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        // when
+        memberApplicationService.signUp(command, response);
+
+        // then
+        Optional<Member> savedMember = memberRepository.findByEmail("test@example.com");
+        assertThat(savedMember).isPresent();
+        assertThat(savedMember.get().getMarketingAgreement().isAgreed()).isFalse();
+    }
+
+    @Test
+    @DisplayName("회원가입 시 마케팅 동의 null인 경우 기본값 false로 저장")
+    void signUpWithNullMarketingAgreement() {
+        // given
+        SignUpCommand command = new SignUpCommand(
+                "널테스트",
+                "컴퓨터공학과",
+                "테스트대학교",
+                "null@example.com",
+                List.of("기타"),
+                null
+        );
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        // when
+        memberApplicationService.signUp(command, response);
+
+        // then
+        Optional<Member> savedMember = memberRepository.findByEmail("null@example.com");
+        assertThat(savedMember).isPresent();
+        assertThat(savedMember.get().getMarketingAgreement().isAgreed()).isFalse();
+    }
+
+    @Test
+    @DisplayName("마케팅 동의 정보 조회 통합 테스트")
+    void getMarketingAgreement_Integration() {
+        // given
+        Member member = createAndSaveMember("get@example.com", true);
+
+        // when
+        MarketingAgreementResponse response = marketingAgreementApplicationService
+                .getMarketingAgreement(member.getId());
+
+        // then
+        assertThat(response.isAgreement()).isTrue();
+        assertThat(response.effectiveDate()).isNotNull();
+        assertThat(response.effectiveDate()).matches("\\d{2}-\\d{2}-\\d{2}"); // yy-MM-dd 형식 확인
+    }
+
+    @Test
+    @DisplayName("마케팅 동의 상태 변경 통합 테스트")
+    void updateMarketingAgreement_Integration() {
+        // given
+        Member member = createAndSaveMember("update@example.com", false);
+        MarketingAgreementUpdateRequest request = new MarketingAgreementUpdateRequest(true);
+
+        // when
+        MarketingAgreementResponse response = marketingAgreementApplicationService
+                .updateMarketingAgreement(member.getId(), request);
+
+        // then
+        assertThat(response.isAgreement()).isTrue();
+        assertThat(response.effectiveDate()).isNotNull();
+
+        // 데이터베이스에서 실제로 변경되었는지 확인
+        Member updatedMember = memberRepository.findById(member.getId()).orElseThrow();
+        assertThat(updatedMember.getMarketingAgreement().isAgreed()).isTrue();
+    }
+
+    @Test
+    @DisplayName("마케팅 동의 상태를 여러 번 변경하는 통합 테스트")
+    void updateMarketingAgreement_MultipleTimes_Integration() {
+        // given
+        Member member = createAndSaveMember("multiple@example.com", false);
+
+        // when & then
+        // 1. false -> true
+        MarketingAgreementUpdateRequest requestTrue = new MarketingAgreementUpdateRequest(true);
+        MarketingAgreementResponse responseTrue = marketingAgreementApplicationService
+                .updateMarketingAgreement(member.getId(), requestTrue);
+        assertThat(responseTrue.isAgreement()).isTrue();
+
+        // 2. true -> false
+        MarketingAgreementUpdateRequest requestFalse = new MarketingAgreementUpdateRequest(false);
+        MarketingAgreementResponse responseFalse = marketingAgreementApplicationService
+                .updateMarketingAgreement(member.getId(), requestFalse);
+        assertThat(responseFalse.isAgreement()).isFalse();
+
+        // 3. 최종 상태 확인
+        MarketingAgreementResponse finalResponse = marketingAgreementApplicationService
+                .getMarketingAgreement(member.getId());
+        assertThat(finalResponse.isAgreement()).isFalse();
+    }
+
+    @Test
+    @DisplayName("동일한 상태로 마케팅 동의 변경 시 날짜는 그대로 유지")
+    void updateMarketingAgreement_SameState_DateUnchanged() {
+        // given
+        Member member = createAndSaveMember("same@example.com", true);
+        MarketingAgreementResponse originalResponse = marketingAgreementApplicationService
+                .getMarketingAgreement(member.getId());
+
+        // when
+        MarketingAgreementUpdateRequest request = new MarketingAgreementUpdateRequest(true);
+        MarketingAgreementResponse updatedResponse = marketingAgreementApplicationService
+                .updateMarketingAgreement(member.getId(), request);
+
+        // then
+        assertThat(updatedResponse.isAgreement()).isTrue();
+        assertThat(updatedResponse.effectiveDate()).isEqualTo(originalResponse.effectiveDate());
+    }
+
+    private Member createAndSaveMember(String email, boolean marketingAgreement) {
+        Member member = Member.builder()
+                .email(email)
+                .nickname("테스트회원")
+                .major("컴퓨터공학과")
+                .school("테스트대학교")
+                .inflow("테스트")
+                .build();
+        member.setMarketingAgreement(marketingAgreement);
+        return memberRepository.save(member);
+    }
+}

--- a/BE/forever/src/test/java/com/example/forever/service/KakaoAuthServiceUnitTest.java
+++ b/BE/forever/src/test/java/com/example/forever/service/KakaoAuthServiceUnitTest.java
@@ -41,7 +41,8 @@ class MemberApplicationServiceIntegrationTest {
                 "소프트웨어공학과", 
                 "전남대학교",
                 "rootachieve@gmail.com",
-                List.of("지인추천", "기타")
+                List.of("지인추천", "기타"),
+                true
         );
 
         // when
@@ -66,7 +67,8 @@ class MemberApplicationServiceIntegrationTest {
                 "null학과",
                 "null대학교",
                 "null@example.com",
-                null
+                null,
+                false
         );
 
         // when
@@ -87,7 +89,8 @@ class MemberApplicationServiceIntegrationTest {
                 "빈리스트학과",
                 "빈리스트대학교",
                 "empty@example.com",
-                List.of()
+                List.of(),
+                null
         );
 
         // when


### PR DESCRIPTION
## 💡 주의
- [x] 브랜치 방향 확인하셨나요? :)

## PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✨ PR 내용
<!-- PR에 대한 내용을 설명해주세요. -->

## 📌 관련 이슈
<!-- 관련 있는 이슈 번호를 {#003}과 같이 기입해주세요.
해당 pull request를 merge할 때, 이슈를 close하려면
{closed #003}과 같이 기입해주세요. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 회원의 마케팅 정보 수신 동의 여부 및 동의 일자를 관리할 수 있는 기능이 추가되었습니다.
  - 회원가입 시 마케팅 동의 여부를 입력 및 저장할 수 있습니다.
  - 마케팅 동의 상태 조회 및 변경을 위한 API 엔드포인트가 제공됩니다.

- **버그 수정**
  - 해당 없음

- **문서화**
  - Swagger/OpenAPI에 마케팅 동의 관련 API 문서가 추가되었습니다.

- **테스트**
  - 마케팅 동의 도메인, 서비스, 애플리케이션 서비스, 컨트롤러, 통합 테스트가 추가되어 관련 기능의 정상 동작을 검증합니다.

- **기타**
  - 데이터베이스에 마케팅 동의 관련 컬럼이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->