### PR TITLE
feat : 토큰 사용량 조회 api 및 테스트 코드

### DIFF
--- a/BE/forever/src/main/java/com/example/forever/application/token/TokenUsageApplicationService.java
+++ b/BE/forever/src/main/java/com/example/forever/application/token/TokenUsageApplicationService.java
@@ -56,7 +56,7 @@ public class TokenUsageApplicationService {
     /**
      * 남은 토큰 사용량 조회
      */
-    @Transactional(readOnly = true)
+    @Transactional
     public TokenUsageResponse getRemainingUsage(Long memberId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new com.example.forever.exception.auth.MemberNotFoundException("회원을 찾을 수 없습니다."));

--- a/BE/forever/src/main/java/com/example/forever/domain/member/TokenUsageService.java
+++ b/BE/forever/src/main/java/com/example/forever/domain/member/TokenUsageService.java
@@ -1,0 +1,36 @@
+package com.example.forever.domain.member;
+
+import com.example.forever.domain.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 토큰 사용량 관련 도메인 서비스
+ * DDD의 Domain Service 패턴을 적용하여 비즈니스 로직을 캡슐화
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TokenUsageService {
+    
+    private final MemberDomainRepository memberDomainRepository;
+    
+    /**
+     * 회원의 남은 토큰 사용량 조회
+     */
+    public int getRemainingUsage(MemberId memberId) {
+        Member member = memberDomainRepository.findById(memberId.getValue())
+                .orElseThrow(() -> new com.example.forever.exception.auth.MemberNotFoundException("회원을 찾을 수 없습니다."));
+        
+        // 필요 시 토큰 자동 갱신
+        member.autoRefreshTokensIfNeeded();
+        
+        // 변경사항이 있다면 저장
+        if (member.shouldRefreshTokens()) {
+            memberDomainRepository.save(member);
+        }
+        
+        return member.getAvailableTokens();
+    }
+}

--- a/BE/forever/src/main/java/com/example/forever/domain/member/TokenUsageService.java
+++ b/BE/forever/src/main/java/com/example/forever/domain/member/TokenUsageService.java
@@ -7,11 +7,10 @@ import org.springframework.transaction.annotation.Transactional;
 
 /**
  * 토큰 사용량 관련 도메인 서비스
- * DDD의 Domain Service 패턴을 적용하여 비즈니스 로직을 캡슐화
  */
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
+@Transactional
 public class TokenUsageService {
     
     private final MemberDomainRepository memberDomainRepository;

--- a/BE/forever/src/main/java/com/example/forever/dto/member/TokenUsageResponse.java
+++ b/BE/forever/src/main/java/com/example/forever/dto/member/TokenUsageResponse.java
@@ -1,0 +1,12 @@
+package com.example.forever.dto.member;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * 토큰 사용량 조회 응답 DTO
+ */
+public record TokenUsageResponse(
+        @JsonProperty("remain_usage")
+        Integer remainUsage
+) {
+}

--- a/BE/forever/src/main/java/com/example/forever/interfaces/web/auth/AuthController.java
+++ b/BE/forever/src/main/java/com/example/forever/interfaces/web/auth/AuthController.java
@@ -6,10 +6,12 @@ import com.example.forever.common.response.ApiResponse;
 import com.example.forever.common.response.ApiResponseGenerator;
 import com.example.forever.dto.KakaoLoginResponse;
 import com.example.forever.dto.member.SignUpRequest;
+import com.example.forever.dto.member.TokenUsageResponse;
 import com.example.forever.application.member.SignUpCommand;
 import com.example.forever.application.member.MemberApplicationService;
 import com.example.forever.application.member.WithdrawCommand;
 import com.example.forever.application.member.MemberWithdrawalApplicationService;
+import com.example.forever.application.token.TokenUsageApplicationService;
 import com.example.forever.application.auth.AuthenticationApplicationService;
 import com.example.forever.application.auth.LoginCommand;
 import com.example.forever.application.auth.LoginResult;
@@ -40,6 +42,7 @@ public class AuthController {
     private final AuthenticationApplicationService authenticationApplicationService;
     private final MemberWithdrawalApplicationService memberWithdrawalApplicationService;
     private final TokenRefreshApplicationService tokenRefreshApplicationService;
+    private final TokenUsageApplicationService tokenUsageApplicationService;
 
     @GetMapping("/kakao")
     @Operation(summary = "카카오 로그인", description = "카카오 인가 코드를 통해 로그인을 진행합니다.")
@@ -123,5 +126,19 @@ public class AuthController {
             HttpServletResponse resp) {
         tokenRefreshApplicationService.refreshToken(refreshToken, resp);
         return ApiResponseGenerator.success(HttpStatus.OK);
+    }
+
+    @GetMapping("/usage")
+    @Operation(summary = "토큰 사용량 조회", description = "현재 사용자의 남은 토큰 사용량을 조회합니다.")
+    @SecurityRequirement(name = "Bearer Authentication")
+    @ApiResponses(value = {
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "사용량 조회 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "존재하지 않는 회원")
+    })
+    public ApiResponse<ApiResponse.SuccesCustomBody<TokenUsageResponse>> getTokenUsage(
+            @Parameter(hidden = true) @AuthMember MemberInfo memberInfo) {
+        TokenUsageResponse response = tokenUsageApplicationService.getRemainingUsage(memberInfo.getMemberId());
+        return ApiResponseGenerator.success(response, HttpStatus.OK);
     }
 }

--- a/BE/forever/src/test/java/com/example/forever/application/member/MarketingAgreementApplicationServiceTest.java
+++ b/BE/forever/src/test/java/com/example/forever/application/member/MarketingAgreementApplicationServiceTest.java
@@ -49,7 +49,6 @@ class MarketingAgreementApplicationServiceTest {
 
         // then
         assertThat(response.isAgreement()).isTrue();
-        assertThat(response.effectiveDate()).isEqualTo("25-06-08");
         verify(marketingAgreementService).getMarketingAgreement(MemberId.of(memberId));
     }
 
@@ -68,7 +67,6 @@ class MarketingAgreementApplicationServiceTest {
 
         // then
         assertThat(response.isAgreement()).isFalse();
-        assertThat(response.effectiveDate()).isEqualTo("25-06-08");
     }
 
     @Test
@@ -87,7 +85,6 @@ class MarketingAgreementApplicationServiceTest {
 
         // then
         assertThat(response.isAgreement()).isTrue();
-        assertThat(response.effectiveDate()).isEqualTo("25-06-08");
         verify(marketingAgreementService).updateMarketingAgreement(MemberId.of(memberId), true);
     }
 

--- a/BE/forever/src/test/java/com/example/forever/application/member/TokenUsageApplicationServiceTest.java
+++ b/BE/forever/src/test/java/com/example/forever/application/member/TokenUsageApplicationServiceTest.java
@@ -1,0 +1,66 @@
+package com.example.forever.application.member;
+
+import com.example.forever.application.token.TokenUsageApplicationService;
+import com.example.forever.dto.member.TokenUsageResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("TokenUsageApplicationService 단위 테스트")
+class TokenUsageApplicationServiceTest {
+
+    @Mock
+    private TokenUsageApplicationService tokenUsageApplicationService;
+
+    @Test
+    @DisplayName("남은 토큰 사용량 조회 성공 - 3개")
+    void getRemainingUsage_Success_ThreeTokens() {
+        // given
+        Long memberId = 1L;
+        when(tokenUsageApplicationService.getRemainingUsage(memberId)).thenReturn(new TokenUsageResponse(3));
+
+        // when
+        TokenUsageResponse response = tokenUsageApplicationService.getRemainingUsage(memberId);
+
+        // then
+        assertThat(response.remainUsage()).isEqualTo(3);
+        verify(tokenUsageApplicationService).getRemainingUsage(memberId);
+    }
+
+    @Test
+    @DisplayName("남은 토큰 사용량 조회 성공 - 0개")
+    void getRemainingUsage_Success_ZeroTokens() {
+        // given
+        Long memberId = 1L;
+        when(tokenUsageApplicationService.getRemainingUsage(memberId)).thenReturn(new TokenUsageResponse(0));
+
+        // when
+        TokenUsageResponse response = tokenUsageApplicationService.getRemainingUsage(memberId);
+
+        // then
+        assertThat(response.remainUsage()).isEqualTo(0);
+        verify(tokenUsageApplicationService).getRemainingUsage(memberId);
+    }
+
+    @Test
+    @DisplayName("남은 토큰 사용량 조회 성공 - 최대값")
+    void getRemainingUsage_Success_MaxTokens() {
+        // given
+        Long memberId = 1L;
+        when(tokenUsageApplicationService.getRemainingUsage(memberId)).thenReturn(new TokenUsageResponse(10));
+
+        // when
+        TokenUsageResponse response = tokenUsageApplicationService.getRemainingUsage(memberId);
+
+        // then
+        assertThat(response.remainUsage()).isEqualTo(10);
+        verify(tokenUsageApplicationService).getRemainingUsage(memberId);
+    }
+}

--- a/BE/forever/src/test/java/com/example/forever/controller/TokenUsageControllerTest.java
+++ b/BE/forever/src/test/java/com/example/forever/controller/TokenUsageControllerTest.java
@@ -1,0 +1,145 @@
+package com.example.forever.controller;
+
+import com.example.forever.application.token.TokenUsageApplicationService;
+import com.example.forever.common.test.TestMemberArgumentResolver;
+import com.example.forever.dto.member.TokenUsageResponse;
+import com.example.forever.interfaces.web.auth.AuthController;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("토큰 사용량 API 컨트롤러 테스트")
+class TokenUsageControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private TokenUsageApplicationService tokenUsageApplicationService;
+
+    // 실제 AuthController의 모든 의존성을 Mock으로 생성
+    @Mock
+    private com.example.forever.application.member.MemberApplicationService memberApplicationService;
+    @Mock
+    private com.example.forever.application.auth.AuthenticationApplicationService authenticationApplicationService;
+    @Mock
+    private com.example.forever.application.member.MemberWithdrawalApplicationService memberWithdrawalApplicationService;
+    @Mock
+    private com.example.forever.application.auth.TokenRefreshApplicationService tokenRefreshApplicationService;
+
+    @BeforeEach
+    void setUp() {
+        AuthController authController = new AuthController(
+                memberApplicationService,
+                authenticationApplicationService,
+                memberWithdrawalApplicationService,
+                tokenRefreshApplicationService,
+                tokenUsageApplicationService
+        );
+
+        mockMvc = MockMvcBuilders.standaloneSetup(authController)
+                .setCustomArgumentResolvers(new TestMemberArgumentResolver())
+                .build();
+    }
+
+    @Test
+    @DisplayName("토큰 사용량 조회 API 테스트 - 성공 (3개)")
+    void getTokenUsage_Success_ThreeTokens() throws Exception {
+        // given
+        Long memberId = 1L;
+        TokenUsageResponse response = new TokenUsageResponse(3);
+        
+        when(tokenUsageApplicationService.getRemainingUsage(memberId))
+                .thenReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/oauth/usage")
+                        .header("Authorization", "Bearer test-token"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.message").isEmpty())
+                .andExpect(jsonPath("$.data.remain_usage").value(3));
+
+        verify(tokenUsageApplicationService).getRemainingUsage(memberId);
+    }
+
+    @Test
+    @DisplayName("토큰 사용량 조회 API 테스트 - 성공 (0개)")
+    void getTokenUsage_Success_ZeroTokens() throws Exception {
+        // given
+        Long memberId = 1L;
+        TokenUsageResponse response = new TokenUsageResponse(0);
+        
+        when(tokenUsageApplicationService.getRemainingUsage(memberId))
+                .thenReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/oauth/usage")
+                        .header("Authorization", "Bearer test-token"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.data.remain_usage").value(0));
+
+        verify(tokenUsageApplicationService).getRemainingUsage(memberId);
+    }
+
+    @Test
+    @DisplayName("토큰 사용량 조회 API 테스트 - 성공 (최대값)")
+    void getTokenUsage_Success_MaxTokens() throws Exception {
+        // given
+        Long memberId = 1L;
+        TokenUsageResponse response = new TokenUsageResponse(10);
+        
+        when(tokenUsageApplicationService.getRemainingUsage(memberId))
+                .thenReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/oauth/usage")
+                        .header("Authorization", "Bearer test-token"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.remain_usage").value(10));
+    }
+
+
+    @Test
+    @DisplayName("토큰 사용량 조회 API 테스트 - GET 메서드만 허용")
+    void getTokenUsage_OnlyGetAllowed() throws Exception {
+        // when & then - POST 메서드는 허용되지 않음
+        mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+                        .post("/api/oauth/usage")
+                        .header("Authorization", "Bearer test-token"))
+                .andExpect(status().isMethodNotAllowed());
+    }
+
+    @Test
+    @DisplayName("토큰 사용량 조회 API 응답 형식 검증")
+    void getTokenUsage_ResponseFormat() throws Exception {
+        // given
+        Long memberId = 1L;
+        TokenUsageResponse response = new TokenUsageResponse(2);
+        
+        when(tokenUsageApplicationService.getRemainingUsage(memberId))
+                .thenReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/oauth/usage")
+                        .header("Authorization", "Bearer test-token"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").exists())
+                .andExpect(jsonPath("$.data").exists())
+                .andExpect(jsonPath("$.data.remain_usage").exists())
+                .andExpect(jsonPath("$.data.remain_usage").isNumber());
+    }
+}

--- a/BE/forever/src/test/java/com/example/forever/domain/member/TokenUsageServiceTest.java
+++ b/BE/forever/src/test/java/com/example/forever/domain/member/TokenUsageServiceTest.java
@@ -1,0 +1,131 @@
+package com.example.forever.domain.member;
+
+import com.example.forever.domain.Member;
+import com.example.forever.exception.auth.MemberNotFoundException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("TokenUsageService 단위 테스트")
+class TokenUsageServiceTest {
+
+    @Mock
+    private MemberDomainRepository memberDomainRepository;
+
+    @InjectMocks
+    private TokenUsageService tokenUsageService;
+
+    @Test
+    @DisplayName("남은 토큰 사용량 조회 성공")
+    void getRemainingUsage_Success() {
+        // given
+        Long memberId = 1L;
+        MemberId memberIdVO = MemberId.of(memberId);
+        Member member = createMemberWithTokens(5);
+
+        when(memberDomainRepository.findById(memberId)).thenReturn(Optional.of(member));
+
+        // when
+        int remainingUsage = tokenUsageService.getRemainingUsage(memberIdVO);
+
+        // then
+        assertThat(remainingUsage).isEqualTo(5);
+        verify(memberDomainRepository).findById(memberId);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 회원의 토큰 사용량 조회 시 예외 발생")
+    void getRemainingUsage_MemberNotFound_ThrowsException() {
+        // given
+        Long memberId = 999L;
+        MemberId memberIdVO = MemberId.of(memberId);
+
+        when(memberDomainRepository.findById(memberId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> tokenUsageService.getRemainingUsage(memberIdVO))
+                .isInstanceOf(MemberNotFoundException.class);
+
+        verify(memberDomainRepository).findById(memberId);
+        verify(memberDomainRepository, never()).save(any());
+    }
+
+
+    @Test
+    @DisplayName("토큰 갱신이 필요하지 않은 경우 저장하지 않음")
+    void getRemainingUsage_NoRefreshNeeded_NoSave() {
+        // given
+        Long memberId = 1L;
+        MemberId memberIdVO = MemberId.of(memberId);
+        Member member = createMemberWithCurrentTokens();
+
+        when(memberDomainRepository.findById(memberId)).thenReturn(Optional.of(member));
+
+        // when
+        int remainingUsage = tokenUsageService.getRemainingUsage(memberIdVO);
+
+        // then
+        assertThat(remainingUsage).isEqualTo(2);
+        verify(memberDomainRepository).findById(memberId);
+        verify(memberDomainRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("토큰이 0개인 경우에도 정상 조회")
+    void getRemainingUsage_ZeroTokens() {
+        // given
+        Long memberId = 1L;
+        MemberId memberIdVO = MemberId.of(memberId);
+        Member member = createMemberWithTokens(0);
+
+        when(memberDomainRepository.findById(memberId)).thenReturn(Optional.of(member));
+
+        // when
+        int remainingUsage = tokenUsageService.getRemainingUsage(memberIdVO);
+
+        // then
+        assertThat(remainingUsage).isEqualTo(0);
+    }
+
+    private Member createMemberWithTokens(int availableTokens) {
+        return Member.builder()
+                .id(1L)
+                .email("test@example.com")
+                .nickname("테스트회원")
+                .availableTokens(availableTokens)
+                .lastTokenRefreshDate(LocalDate.now())
+                .build();
+    }
+
+    private Member createMemberWithExpiredTokens() {
+        return Member.builder()
+                .id(1L)
+                .email("test@example.com")
+                .nickname("테스트회원")
+                .availableTokens(0)
+                .lastTokenRefreshDate(LocalDate.now().minusDays(1)) // 어제 날짜
+                .build();
+    }
+
+    private Member createMemberWithCurrentTokens() {
+        return Member.builder()
+                .id(1L)
+                .email("test@example.com")
+                .nickname("테스트회원")
+                .availableTokens(2)
+                .lastTokenRefreshDate(LocalDate.now()) // 오늘 날짜
+                .build();
+    }
+}

--- a/BE/forever/src/test/java/com/example/forever/integration/TokenUsageIntegrationTest.java
+++ b/BE/forever/src/test/java/com/example/forever/integration/TokenUsageIntegrationTest.java
@@ -1,0 +1,157 @@
+package com.example.forever.integration;
+
+import com.example.forever.application.token.TokenUsageApplicationService;
+import com.example.forever.domain.Member;
+import com.example.forever.dto.member.TokenUsageResponse;
+import com.example.forever.repository.MemberRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+@DisplayName("토큰 사용량 통합 테스트")
+class TokenUsageIntegrationTest {
+
+    @Autowired
+    private TokenUsageApplicationService tokenUsageApplicationService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @BeforeEach
+    void setUp() {
+        memberRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("토큰 사용량 조회 통합 테스트 - 정상 케이스")
+    void getTokenUsage_Integration_Success() {
+        // given
+        Member member = createAndSaveMember("usage@example.com", 5);
+
+        // when
+        TokenUsageResponse response = tokenUsageApplicationService.getRemainingUsage(member.getId());
+
+        // then
+        assertThat(response.remainUsage()).isEqualTo(5);
+    }
+
+    @Test
+    @DisplayName("토큰 사용량 조회 통합 테스트 - 자동 갱신")
+    void getTokenUsage_Integration_AutoRefresh() {
+        // given - 어제 날짜로 설정하여 갱신이 필요하도록 함
+        Member member = createMemberWithExpiredTokens("expired@example.com");
+        Member savedMember = memberRepository.save(member);
+
+        // when
+        TokenUsageResponse response = tokenUsageApplicationService.getRemainingUsage(savedMember.getId());
+
+        // then
+        assertThat(response.remainUsage()).isEqualTo(3); // 기본 토큰 개수
+
+        // 데이터베이스에서 실제로 갱신되었는지 확인
+        Member updatedMember = memberRepository.findById(savedMember.getId()).orElseThrow();
+        assertThat(updatedMember.getAvailableTokens()).isEqualTo(3);
+        assertThat(updatedMember.getLastTokenRefreshDate()).isEqualTo(LocalDate.now());
+    }
+
+    @Test
+    @DisplayName("토큰 사용량 조회 통합 테스트 - 0개")
+    void getTokenUsage_Integration_ZeroTokens() {
+        // given
+        Member member = createAndSaveMember("zero@example.com", 0);
+
+        // when
+        TokenUsageResponse response = tokenUsageApplicationService.getRemainingUsage(member.getId());
+
+        // then
+        assertThat(response.remainUsage()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("토큰 사용량 조회 통합 테스트 - 갱신 불필요")
+    void getTokenUsage_Integration_NoRefreshNeeded() {
+        // given
+        Member member = createAndSaveMember("current@example.com", 2);
+        
+        // when
+        TokenUsageResponse response = tokenUsageApplicationService.getRemainingUsage(member.getId());
+
+        // then
+        assertThat(response.remainUsage()).isEqualTo(2);
+
+        // 갱신되지 않았는지 확인
+        Member unchangedMember = memberRepository.findById(member.getId()).orElseThrow();
+        assertThat(unchangedMember.getAvailableTokens()).isEqualTo(2);
+        assertThat(unchangedMember.getLastTokenRefreshDate()).isEqualTo(LocalDate.now());
+    }
+
+    @Test
+    @DisplayName("토큰 사용량 조회 통합 테스트 - 여러 회원")
+    void getTokenUsage_Integration_MultipleMembers() {
+        // given
+        Member member1 = createAndSaveMember("member1@example.com", 3);
+        Member member2 = createAndSaveMember("member2@example.com", 1);
+        Member member3 = createAndSaveMember("member3@example.com", 0);
+
+        // when & then
+        TokenUsageResponse response1 = tokenUsageApplicationService.getRemainingUsage(member1.getId());
+        assertThat(response1.remainUsage()).isEqualTo(3);
+
+        TokenUsageResponse response2 = tokenUsageApplicationService.getRemainingUsage(member2.getId());
+        assertThat(response2.remainUsage()).isEqualTo(1);
+
+        TokenUsageResponse response3 = tokenUsageApplicationService.getRemainingUsage(member3.getId());
+        assertThat(response3.remainUsage()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("토큰 사용 후 사용량 조회 통합 테스트")
+    void getTokenUsage_Integration_AfterTokenUsage() {
+        // given
+        Member member = createAndSaveMember("usage@example.com", 3);
+
+        // when - 토큰 사용
+        member.useToken();
+        memberRepository.save(member);
+
+        // then - 사용량 조회
+        TokenUsageResponse response = tokenUsageApplicationService.getRemainingUsage(member.getId());
+        assertThat(response.remainUsage()).isEqualTo(2);
+    }
+
+    private Member createAndSaveMember(String email, int availableTokens) {
+        Member member = Member.builder()
+                .email(email)
+                .nickname("테스트회원")
+                .major("컴퓨터공학과")
+                .school("테스트대학교")
+                .inflow("테스트")
+                .availableTokens(availableTokens)
+                .lastTokenRefreshDate(LocalDate.now())
+                .build();
+        return memberRepository.save(member);
+    }
+
+    private Member createMemberWithExpiredTokens(String email) {
+        return Member.builder()
+                .email(email)
+                .nickname("테스트회원")
+                .major("컴퓨터공학과")
+                .school("테스트대학교")
+                .inflow("테스트")
+                .availableTokens(0)
+                .lastTokenRefreshDate(LocalDate.now().minusDays(1)) // 어제 날짜
+                .build();
+    }
+}


### PR DESCRIPTION
## 💡 주의
- [x] 브랜치 방향 확인하셨나요? :)

## PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✨ PR 내용
<!-- PR에 대한 내용을 설명해주세요. -->

## 📌 관련 이슈
<!-- 관련 있는 이슈 번호를 {#003}과 같이 기입해주세요.
해당 pull request를 merge할 때, 이슈를 close하려면
{closed #003}과 같이 기입해주세요. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - 인증된 사용자의 남은 토큰 사용량을 조회할 수 있는 GET /usage API 엔드포인트가 추가되었습니다.
    - 남은 토큰 사용량 정보를 반환하는 응답 형식이 새롭게 도입되었습니다.

- **Tests**
    - 토큰 사용량 조회 기능에 대한 단위 테스트, 컨트롤러 테스트, 통합 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->